### PR TITLE
HOTFIX Change drop time source to teuns API

### DIFF
--- a/mcsniperpy/sniper.py
+++ b/mcsniperpy/sniper.py
@@ -155,13 +155,11 @@ class Sniper:
                 "init_path"), "accounts.txt")
         )
 
-        # droptime = await {"kqzz_api": api_timing, "namemc": namemc_timing}.get(
-        #     self.timing_system, "kqzz_api"
-        # )(target, self.session)
-        
-        droptime = await {"kqzz_api": api_timing, "namemc": teun_timing}.get(
-            self.timing_system, "kqzz_api"
-        )(target, self.session)
+        droptime = await {
+            "kqzz_api": api_timing,
+            "namemc": namemc_timing,
+            "teun": teun_timing
+        }.get(self.timing_system, "kqzz_api")(target, self.session)
 
 
         await self.snipe(droptime, target, offset)

--- a/mcsniperpy/sniper.py
+++ b/mcsniperpy/sniper.py
@@ -9,7 +9,7 @@ import aiohttp
 from mcsniperpy.util import announce, request_manager
 from mcsniperpy.util import utils as util
 from mcsniperpy.util.classes.config import BackConfig, Config, populate_configs
-from mcsniperpy.util.name_system import api_timing, namemc_timing
+from mcsniperpy.util.name_system import api_timing, namemc_timing, teun_timing
 
 
 class Sniper:
@@ -155,9 +155,14 @@ class Sniper:
                 "init_path"), "accounts.txt")
         )
 
-        droptime = await {"kqzz_api": api_timing, "namemc": namemc_timing}.get(
+        # droptime = await {"kqzz_api": api_timing, "namemc": namemc_timing}.get(
+        #     self.timing_system, "kqzz_api"
+        # )(target, self.session)
+        
+        droptime = await {"kqzz_api": api_timing, "namemc": teun_timing}.get(
             self.timing_system, "kqzz_api"
         )(target, self.session)
+
 
         await self.snipe(droptime, target, offset)
 

--- a/mcsniperpy/util/name_system.py
+++ b/mcsniperpy/util/name_system.py
@@ -69,7 +69,18 @@ async def namemc_timing(username: str, session: RequestManager) -> float:
     close(1)
     return 0
 
-
+async def teun_timing(username: str) -> int:
+    r = await requests.get(f"https://mojang-api.teun.lol/droptime/{username}")
+    if r.status_code != 200:
+        log.error(f"Couldn't get time from teun's API. Status: {r.status}")
+        close(1)
+    if "UNIX" in r.json():
+        log.info(f"sniping {username} @ {r.json()['UNIX']}")
+        return r.json()["UNIX"]
+    prev = input("Whats the name of the previous owner?\n>")
+    r = requests.post("https://mojang-api.teun.lol/upload-droptime", json={'name': username, 'prevOwner': prev})
+    return r.json()["UNIX"]
+             
 async def api_timing(
     username: str,
     session: RequestManager

--- a/mcsniperpy/util/name_system.py
+++ b/mcsniperpy/util/name_system.py
@@ -69,6 +69,7 @@ async def namemc_timing(username: str, session: RequestManager) -> float:
     close(1)
     return 0
 
+
 async def teun_timing(
     username: str,
     session: RequestManager

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="MCsniperPY",
-    version="0.20.3",
+    version="0.20.4",
     description="Minecraft name sniper written in Python",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I wrote this code in 10 minutes. I have no idea if it works - but it should. 
I added a small function that gets the unix timestamp of a drop from teuns API, instead of scraping NameMC. I replaced the call to `namemc_timing` in `sniper.py`  with a call to the new function, `teun_timing`.

I am sorry if I am wasting time by submitting bad code - this is meant as a base.