### PR TITLE
Update droptime apis.

### DIFF
--- a/mcsniperpy/sniper.py
+++ b/mcsniperpy/sniper.py
@@ -180,7 +180,7 @@ class Sniper:
             "teun": teun_timing,
             "ckm": coolkidmacho_timing,
             "coolkidmacho": coolkidmacho_timing,
-        }.get(self.timing_system, "teun")(target, self.session)
+        }.get(self.timing_system, "ckm")(target, self.session)
 
         await self.snipe(droptime, target, offset)
 

--- a/mcsniperpy/util/classes/config.py
+++ b/mcsniperpy/util/classes/config.py
@@ -72,7 +72,7 @@ class Config:
 def create_user_config() -> configparser.ConfigParser:
     user_config = configparser.ConfigParser(allow_no_value=True)
     user_config["sniper"] = {
-        "timing_system": "teun",
+        "timing_system": "ckm",
         "auto_claim_namemc": "no",
         "snipe_requests": "3",
     }

--- a/mcsniperpy/util/name_system.py
+++ b/mcsniperpy/util/name_system.py
@@ -97,7 +97,7 @@ async def coolkidmacho_timing(
         session: RequestManager
 ):
     resp, _, resp_json = await session.get(
-        f"https://api.coolkidmacho.com/droptime/{username}"
+        f"http://api.coolkidmacho.com/droptime/{username}"
     )
 
     if resp.status < 300:


### PR DESCRIPTION
Due to teuns API redirecting to https://api.coolkidmacho.com/ change the default droptime API.