### PR TITLE
Fixed encoding issues

### DIFF
--- a/mcsniperpy/util/classes/config.py
+++ b/mcsniperpy/util/classes/config.py
@@ -130,12 +130,12 @@ def populate_configs(no_confirm=False):
         if log.yes_or_no("Overwrite current accounts file:"):
             with open(
                 os.path.join(config["sniper"]["init_path"],
-                             "accounts.txt"), "w"
+                             "accounts.txt"), "w", encoding="utf-8"
             ) as file:
                 file.write(DEFAULT_ACCOUNTS_FILE)
     else:
         with open(
-            os.path.join(config["sniper"]["init_path"], "accounts.txt"), "w"
+            os.path.join(config["sniper"]["init_path"], "accounts.txt"), "w", encoding="utf-8"
         ) as file:
             file.write(DEFAULT_ACCOUNTS_FILE)
 

--- a/mcsniperpy/util/utils.py
+++ b/mcsniperpy/util/utils.py
@@ -25,7 +25,7 @@ def parse_accs(file_path) -> List[Account]:
     accounts = list()
     log.debug(f"accounts path: {file_path}")
     if os.path.isfile(file_path):
-        lines = [line.strip().split(":") for line in open(file_path).readlines()]
+        lines = [line.strip().split(":") for line in open(file_path, encoding="utf-8").readlines()]
     else:
         log.error("accounts.txt file not found!")
         close(1)


### PR DESCRIPTION
Let's say you have a "ñ" in your Minecraft password (which Mojang allows you to do), when you put the email and password in the accounts.txt file, you will probably get a "[error] failed to auth email@domain.com" because the encoding is different

For example, in my windows 10 machine with python 3.7 the default encoding for open() is set to "cp1252" but I previously opened my file with utf-8 in notepad and python still open it with cp1252, that means if I write "email@domain.com:passwordñ" in accounts.txt in notepad with utf-8 encoding, the password would be "passwordÃ±" because the default encoding (cp1252) is used in python.
![image](https://user-images.githubusercontent.com/29165787/127709451-b3b402ac-ef7f-47b4-b7b6-e7b54a994a7f.png)
